### PR TITLE
Render static HTML without extensions

### DIFF
--- a/lib/griffin_ssg_app.ex
+++ b/lib/griffin_ssg_app.ex
@@ -12,7 +12,7 @@ defmodule GriffinSSGApp do
     Supervisor.start_link(children, strategy: :one_for_one, name: Griffin.Supervisor)
   end
 
-  defp http_port do
+  def http_port do
     fallback =
       "GRIFFIN_HTTP_PORT"
       |> System.get_env(@default_port)

--- a/lib/mix/tasks/grf.server.ex
+++ b/lib/mix/tasks/grf.server.ex
@@ -20,8 +20,10 @@ defmodule Mix.Tasks.Grf.Server do
       $ mix do deps.loadpaths --no-deps-check, phx.server
   """
 
-  @impl true
+  @impl Mix.Task
   def run(args) do
+    port = GriffinSSGApp.http_port
+    IO.puts "Starting webserver on #{port}"
     Application.put_env(:griffin_ssg, :server, true, persistent: true)
     Mix.Tasks.Run.run(open_args(args) ++ run_args())
   end

--- a/lib/mix/tasks/grf.server.ex
+++ b/lib/mix/tasks/grf.server.ex
@@ -23,8 +23,8 @@ defmodule Mix.Tasks.Grf.Server do
   @impl Mix.Task
   def run(args) do
     port = GriffinSSGApp.http_port
-    IO.puts "Starting webserver on #{port}"
     Application.put_env(:griffin_ssg, :server, true, persistent: true)
+    Mix.shell().info "Starting webserver on http://localhost:#{port}"
     Mix.Tasks.Run.run(open_args(args) ++ run_args())
   end
 

--- a/lib/mix/tasks/grf.server.ex
+++ b/lib/mix/tasks/grf.server.ex
@@ -22,9 +22,9 @@ defmodule Mix.Tasks.Grf.Server do
 
   @impl Mix.Task
   def run(args) do
-    port = GriffinSSGApp.http_port
+    port = GriffinSSGApp.http_port()
     Application.put_env(:griffin_ssg, :server, true, persistent: true)
-    Mix.shell().info "Starting webserver on http://localhost:#{port}"
+    Mix.shell().info("Starting webserver on http://localhost:#{port}")
     Mix.Tasks.Run.run(open_args(args) ++ run_args())
   end
 

--- a/lib/web/plug.ex
+++ b/lib/web/plug.ex
@@ -10,12 +10,21 @@ defmodule GriffinSSG.Web.Plug do
 
   use Plug.Builder
 
-  plug(Plug.Static,
-    at: "/",
-    from: @output_path
-  )
+  plug(:implicit_index_html)
+
+  plug(Plug.Static, at: "/", from: @output_path)
 
   plug(:not_found)
+
+  def implicit_index_html(conn, _) do
+    path = conn.request_path
+    if Path.extname(path) == "" do
+      path = if String.ends_with?(path, "/"), do: path, else: "#{path}/"
+      %{conn | request_path: "#{path}index.html", path_info: conn.path_info ++ ["index.html"] }
+    else
+      conn
+    end
+  end
 
   def not_found(conn, _) do
     send_resp(conn, 404, "not found")

--- a/lib/web/plug.ex
+++ b/lib/web/plug.ex
@@ -18,9 +18,10 @@ defmodule GriffinSSG.Web.Plug do
 
   def implicit_index_html(conn, _) do
     path = conn.request_path
+
     if Path.extname(path) == "" do
       path = if String.ends_with?(path, "/"), do: path, else: "#{path}/"
-      %{conn | request_path: "#{path}index.html", path_info: conn.path_info ++ ["index.html"] }
+      %{conn | request_path: "#{path}index.html", path_info: conn.path_info ++ ["index.html"]}
     else
       conn
     end


### PR DESCRIPTION
Hey!
Thank you for working on static site generator for Elixir. I've just started playing with it and noticed that dev server does not render `index.html` files for directories (e.g. `http://localhost:4123`, `http://localhost:4123/readme/`, `http://localhost:4123/readme`, etc.). This PR improves that by introducing a simple plug that runs before `Plug.Static`.

Btw. do you plan to introduce live-reloading with custom watchers (e.g. to support Tailwind)?