### PR TITLE
Additional Watch Directories for mix grf.server

### DIFF
--- a/lib/mix/tasks/grf.server.ex
+++ b/lib/mix/tasks/grf.server.ex
@@ -32,10 +32,11 @@ defmodule Mix.Tasks.Grf.Server do
 
     port = http_port(opts)
 
-    input_directories = [
-      Application.get_env(:griffin_ssg, :input, "src"),
-      Application.get_env(:griffin_ssg, :layouts, "lib/layouts")
-    ]
+    input_directories =
+      [
+        Application.get_env(:griffin_ssg, :input, "src"),
+        Application.get_env(:griffin_ssg, :layouts, "lib/layouts")
+      ] ++ Application.get_env(:griffin_ssg, :additional_watch_directories, [])
 
     live_reload_watch_dirs = [
       ~r"#{Application.get_env(:griffin_ssg, :output, "_site")}/*"


### PR DESCRIPTION
allows a configuration setting for `additional_watch_directories` which is useful for running asset compilation when running `mix grf.server` and live reloading

Used like this

```elixir
config :griffin_ssg,
  additional_watch_directories: ["assets/css"],
  hooks: %{
    before: [
      fn _ ->
        DartSass.install_and_run(:default, ["--no-source-map", "--style=compressed"])
      end
    ],
    after: []
  }
```