### PR TITLE
Merge nested layout assigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for 0.4
 
+## 0.4.2
+
+- Enable referencing frontmatter variables from parent layouts in child layouts
+
 ## 0.4.1
 
 ### Fixes

--- a/guides/getting_started/quick_start.md
+++ b/guides/getting_started/quick_start.md
@@ -50,10 +50,10 @@ Here's what the terminal might look like after you've run this command:
 
 ```console
 ~/blog $ mix grf.build
-Wrote 0 files in 0.03 seconds (v0.4.0)
+Wrote 0 files in 0.03 seconds (v0.4.2)
 ```
 
-If you see `(v0.4.0)` that means you're running the latest version of Griffin. Note that Griffin didn't process any files -- this was expected, since we've not added templates yet.
+Check the printed version to ensure you're running the latest version. Note that Griffin didn't process any files -- this was expected, since we've not added templates yet.
 
 ### 4. Create some templates
 
@@ -86,7 +86,7 @@ The output may look like this:
 ~/blog $ mix grf.build
 Writing _site/README/index.html from ./README.md (earmark)
 Writing _site/index.html from ./index.md (earmark)
-Wrote 2 files in 0.06 seconds (v0.4.0)
+Wrote 2 files in 0.06 seconds (v0.4.2)
 ```
 
 We’ve compiled our two content templates in the current directory into the output folder (`_site` is the default).

--- a/lib/mix/tasks/grf.build.ex
+++ b/lib/mix/tasks/grf.build.ex
@@ -457,11 +457,12 @@ defmodule Mix.Tasks.Grf.Build do
       |> Map.merge(shortcodes_assigns())
       |> Map.merge(partials_assigns())
       |> Map.merge(opts.global_assigns)
+      |> Map.merge(Layouts.get_layout_assigns(layout_name))
       |> Map.merge(%{page: page, collections: opts.collections})
       |> Map.merge(data)
       |> Map.put_new(:title, "Griffin")
 
-    layout = fetch_layout(layout_name)
+    layout = Layouts.get_compiled_layout(layout_name)
 
     if layout == nil do
       Mix.raise("File #{file} specified layout `#{layout_name}` but no such layout was found")
@@ -715,15 +716,11 @@ defmodule Mix.Tasks.Grf.Build do
     end
   end
 
-  defp fetch_layout(name) do
-    ets_lookup(:griffin_build_layouts, name)
-  end
-
   defp fetch_parsed_files do
     ets_lookup(@parsed_files_table, :parsed_files, [])
   end
 
-  defp ets_lookup(table, key, default \\ nil) do
+  defp ets_lookup(table, key, default) do
     case :ets.lookup(table, key) do
       [] -> default
       [{^key, value}] -> value

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Griffin.MixProject do
   use Mix.Project
 
-  @version "0.4.1"
+  @version "0.4.2"
   @scm_url "https://github.com/elixir-griffin/griffin"
 
   def project do

--- a/test/mix/tasks/grf.build_test.exs
+++ b/test/mix/tasks/grf.build_test.exs
@@ -188,7 +188,7 @@ defmodule Mix.Tasks.Grf.BuildTest do
   end
 
   @tag :tmp_dir
-  test "can render nested layouts", %{tmp_dir: tmp_dir} do
+  test "can render nested layouts with assigns", %{tmp_dir: tmp_dir} do
     File.mkdir_p!(tmp_dir <> "/src")
 
     File.write!(tmp_dir <> "/src/a.md", """
@@ -209,16 +209,18 @@ defmodule Mix.Tasks.Grf.BuildTest do
     File.write!(tmp_dir <> "/layouts/b.eex", """
     ---
     layout: "a"
+    language: Elixir
     ---
     <h1>Griffin Times</h1>
     <%= @content%>
     """)
 
+    # lets reference a frontmatter variable from the parent layout
     File.write!(tmp_dir <> "/layouts/c.eex", """
     ---
     layout: "b"
     ---
-    <h2>Elixir News</h2>
+    <h2><%= @language %> News</h2>
     <%= @content%>
     """)
 
@@ -230,11 +232,13 @@ defmodule Mix.Tasks.Grf.BuildTest do
     <%= @content%>
     """)
 
+    # lets reference a frontmatter variable from layouts `b` and from `e` itself
     File.write!(tmp_dir <> "/layouts/e.eex", """
     ---
     layout: "d"
+    latest_elixir: 1.18
     ---
-    <h4>Version 1.14</h4>
+    <h4><%= @language %> version <%= @latest_elixir %></h4>
     <%= @content%>
     """)
 
@@ -257,7 +261,7 @@ defmodule Mix.Tasks.Grf.BuildTest do
       assert file =~ "<h1>Griffin Times"
       assert file =~ "<h2>Elixir News"
       assert file =~ "<h3>Releases"
-      assert file =~ "<h4>Version 1.14"
+      assert file =~ "<h4>Elixir version 1.18"
       assert file =~ "Nesting layouts"
       assert file =~ "how to lose the joy of life in one simple feature"
     end)


### PR DESCRIPTION
Griffin supports nested layouts with a maximum depth of 10. The following setup is supported:

`src/alpha.md`
```
---
title: Nested Layouts
layout: bravo
---
I'm a page being rendered from a nested layout!
```

`lib/layouts/bravo.eex`
```
---
layout: charlie
version: 1.18
---
<h1>Running from <%= @language %> v<%= @version %></h1>
<%= @content %>
```

`lib/layouts/charlie.eex`
```
---
language: Elixir
---
<html>
  <title><%= @title %></title>
<body>
  <p><%= @content %></p>
</body>
</html>
```

While this setup was supported, before this PR, the layout's frontmatter was only read for the `layout` field, meaning that we could not reference any other fields in layout files, not even the current layout.

After these changes this setup works as expected and produces the following HTML output for `alpha.md`:
```
<html>
  <title>Nested Layouts</title>
<body>
  <h1>Fun Times</h1>
  <h2>Running from Elixir v1.18</h2>
  <p>I'm a page being rendered from a nested layout!</p>
</body>
</html>
```